### PR TITLE
Allow servicemanager call to fail

### DIFF
--- a/src/binder_nfc_plugin.c
+++ b/src/binder_nfc_plugin.c
@@ -130,15 +130,18 @@ binder_nfc_plugin_service_list_proc(
     void* plugin)
 {
     BinderNfcPlugin* self = BINDER_NFC_PLUGIN(plugin);
-    char** ptr;
 
     self->list_call_id = 0;
-    for (ptr = services; *ptr; ptr++) {
-        if (g_str_has_prefix(*ptr, BINDER_NFC)) {
-            const char* sep = strchr(*ptr, '/');
+    if (services) {
+        char** ptr;
 
-            if (sep) {
-                binder_nfc_plugin_add_adapter(self, sep + 1);
+        for (ptr = services; *ptr; ptr++) {
+            if (g_str_has_prefix(*ptr, BINDER_NFC)) {
+                const char* sep = strchr(*ptr, '/');
+
+                if (sep) {
+                    binder_nfc_plugin_add_adapter(self, sep + 1);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes this crash:
```
Core was generated by `/usr/sbin/nfcd -o syslog'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  binder_nfc_plugin_service_list_proc (sm=<optimized out>, services=0x0, plugin=0x11f8038) at binder_nfc_plugin.c:135
[Current thread is 1 (Thread 0xeddbe220 (LWP 2962))]
(gdb) bt
#0  binder_nfc_plugin_service_list_proc (sm=<optimized out>, services=0x0, plugin=0x11f8038) at binder_nfc_plugin.c:135
#1  0xed8ec786 in gbinder_servicemanager_list_tx_done (tx=<optimized out>) at gbinder_servicemanager.c:169
#2  0xed8e71fa in gbinder_eventloop_glib_callback_dispatch (source=<optimized out>, callback=<optimized out>, user_data=<optimized out>) at gbinder_eventloop.c:145
#3  0xee0cd2b6 in g_main_dispatch (context=0x1203830) at gmain.c:3179
#4  g_main_context_dispatch (context=0x1203830) at gmain.c:3844
#5  0xee0cd524 in g_main_context_iterate (context=0x1203830, block=1, dispatch=1, self=<optimized out>) at gmain.c:3917
#6  0xee0cd760 in g_main_loop_run (loop=0x12166e0) at gmain.c:4111
#7  0x00017e82 in nfcd_run (opts=0xffe915a0, opts=0xffe915a0) at main.c:121
#8  main (argc=<optimized out>, argv=<optimized out>) at main.c:344
(gdb)
```