### PR TITLE
Add support for AIDL binder interface.

### DIFF
--- a/rpm/nfcd-binder-plugin.spec
+++ b/rpm/nfcd-binder-plugin.spec
@@ -47,7 +47,6 @@ systemctl reload-or-try-restart nfcd.service ||:
 systemctl reload-or-try-restart nfcd.service ||:
 
 %files
-%defattr(-,root,root,-)
 %dir %{plugin_dir}
 %{plugin_dir}/*.so
 %if %{license_support} == 0

--- a/src/binder_nfc.h
+++ b/src/binder_nfc.h
@@ -61,8 +61,12 @@ GType binder_nfc_target_get_type(void);
 #define BINDER_IFACE(x)     "android.hardware.nfc@1.0::" x
 #define BINDER_NFC          BINDER_IFACE("INfc")
 #define BINDER_NFC_CALLBACK BINDER_IFACE("INfcClientCallback")
+#define BINDER_NFC_NAME     BINDER_NFC "/default"
 
-#define DEFAULT_INSTANCE    "default"
+#define BINDER_IFACE_AIDL(x)     "android.hardware.nfc." x
+#define BINDER_NFC_AIDL          BINDER_IFACE_AIDL("INfc")
+#define BINDER_NFC_AIDL_CALLBACK BINDER_IFACE_AIDL("INfcClientCallback")
+#define BINDER_NFC_NAME_AIDL     BINDER_NFC_AIDL "/default"
 
 NfcAdapter*
 binder_nfc_adapter_new(


### PR DESCRIPTION
Add instance name to interface when watching services to fix waiting
for interface to appear on servicemanager.
Remove not needed defattr from spec.