### PR TITLE
Fix AIDL close call

### DIFF
--- a/src/binder_nfc_adapter.c
+++ b/src/binder_nfc_adapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 Slava Monich <slava@monich.com>
+ * Copyright (C) 2018-2026 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2021 Jolla Ltd.
  *
  * You may use this file under the terms of the BSD license as follows:
@@ -388,7 +388,7 @@ binder_nfc_adapter_close_complete(
             self->close_cplt = NULL;
             binder_nfc_adapter_close_done(self);
         } else {
-            GWARN("Power on error");
+            GWARN("Power off error");
             self->close_cplt = NULL;
             binder_nfc_adapter_close_done(self);
         }

--- a/src/binder_nfc_api_aidl.c
+++ b/src/binder_nfc_api_aidl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Slava Monich <slava@monich.com>
+ * Copyright (C) 2025-2026 Slava Monich <slava@monich.com>
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -315,16 +315,17 @@ binder_nfc_api_aidl_close(
     GDestroyNotify destroy,
     gpointer user_data)
 {
+    gulong id;
     GBinderLocalRequest* req = gbinder_client_new_request(api->client);
 
     gbinder_local_request_append_int32(req, BINDER_NFC_AIDL_CLOSE_DISABLE);
-
-    /* binder_nfc_api_aidl_call unrefs the request */
-    return gbinder_client_transact(api->client,
-        BINDER_NFC_AIDL_REQ_CLOSE, 0, NULL,
+    id = gbinder_client_transact(api->client,
+        BINDER_NFC_AIDL_REQ_CLOSE, 0, req,
         binder_nfc_api_aidl_close_complete,
         binder_nfc_api_call_destroy,
         binder_nfc_api_call_new(api, complete, destroy, user_data));
+    gbinder_local_request_unref(req);
+    return id;
 }
 
 static


### PR DESCRIPTION
The plugin was leaking memory on each close:
```
==48556== HEAP SUMMARY:
==48556==     in use at exit: 235,520 bytes in 2,993 blocks
==48556==   total heap usage: 20,877 allocs, 17,884 frees, 1,385,724 bytes allocated
==48556== 
==48556== 960 (288 direct, 672 indirect) bytes in 4 blocks are definitely lost in loss record 2,417 of 2,435
==48556==    at 0x4925D28: malloc (vg_replace_malloc.c:447)
==48556==    by 0x4D06837: g_malloc (gmem.c:100)
==48556==    by 0x9103957: gbinder_local_request_new.part.0 (gbinder_local_request.c:83)
==48556==    by 0x905436F: binder_nfc_api_aidl_close (binder_nfc_api_aidl.c:318)
==48556==    by 0x9053FB7: binder_nfc_api_close (binder_nfc_api.c:164)
==48556==    by 0x9052F0B: binder_nfc_adapter_close (binder_nfc_adapter.c:418)
==48556==    by 0x4C28737: _g_closure_invoke_va (gclosure.c:980)
==48556==    by 0x4C3EBEB: signal_emit_valist_unlocked (gsignal.c:3439)
==48556==    by 0x4C4435F: g_signal_emit_valist (gsignal.c:3278)
==48556==    by 0x4C443F3: g_signal_emit (gsignal.c:3598)
==48556==    by 0x4C28737: _g_closure_invoke_va (gclosure.c:980)
==48556==    by 0x4C3EBEB: signal_emit_valist_unlocked (gsignal.c:3439)
==48556==    by 0x4C4435F: g_signal_emit_valist (gsignal.c:3278)
==48556==    by 0x4C443F3: g_signal_emit (gsignal.c:3598)
==48556==    by 0x9085D6F: nci_sm_emit_pending_signals.part.0 (nci_sm.c:168)
==48556==    by 0x9086523: nci_sm_emit_pending_signals (nci_sm.c:603)
==48556==    by 0x9086523: nci_sm_enter_state (nci_sm.c:598)
==48556==    by 0x90831E7: nci_core_sar_handle_response (nci_core.c:681)
==48556==    by 0x9084F8B: nci_sar_hal_client_read (nci_sar.c:634)
==48556==    by 0x50EC053: ffi_call_SYSV (sysv.S:141)
==48556==    by 0x50E875B: ffi_call_int (ffi.c:829)
==48556==    by 0x4C290BF: g_cclosure_marshal_generic_va (gclosure.c:1743)
==48556==    by 0x4C28737: _g_closure_invoke_va (gclosure.c:980)
==48556==    by 0x4C3EBEB: signal_emit_valist_unlocked (gsignal.c:3439)
==48556==    by 0x4C4435F: g_signal_emit_valist (gsignal.c:3278)
==48556==    by 0x4C443F3: g_signal_emit (gsignal.c:3598)
==48556==    by 0x9054723: binder_nfc_api_aidl_handle_data (binder_nfc_api_aidl.c:178)
==48556==    by 0x9054723: binder_nfc_api_aidl_callback_handler (binder_nfc_api_aidl.c:210)
==48556==    by 0x9100DE3: gbinder_ipc_looper_tx_handle (gbinder_ipc.c:499)
==48556==    by 0x90FDD0F: gbinder_eventloop_glib_callback_dispatch (gbinder_eventloop.c:152)
==48556==    by 0x4CFC293: g_main_dispatch (gmain.c:3565)
==48556==    by 0x4CFFBDB: g_main_context_dispatch_unlocked (gmain.c:4425)
==48556==    by 0x4CFFBDB: g_main_context_iterate_unlocked.isra.0 (gmain.c:4490)
==48556==    by 0x4D006AB: g_main_loop_run (gmain.c:4695)
==48556==    by 0x40183E3: nfcd_run (main.c:119)
==48556==    by 0x40183E3: main (main.c:343)
==48556== 
==48556== LEAK SUMMARY:
==48556==    definitely lost: 288 bytes in 4 blocks
==48556==    indirectly lost: 672 bytes in 8 blocks
==48556==      possibly lost: 2,128 bytes in 7 blocks
==48556==    still reachable: 205,728 bytes in 2,685 blocks
==48556==         suppressed: 0 bytes in 0 blocks
```
also, this appears in the nfcd debug log after closing the adapter:
```
2026-05-14 06:49:22 [binder] Closing adapter
2026-05-14 06:49:22 [binder] WARNING: Power on error
2026-05-14 06:49:22 [binder] Power off
```
apparently caused by missing binder call arguments (`"Power on"` was a typo, `"Power off"` was meant - that's fixed too)